### PR TITLE
clone product object passed to form for update

### DIFF
--- a/exercise-files/remove-products/src/components/ManageProducts.vue
+++ b/exercise-files/remove-products/src/components/ManageProducts.vue
@@ -14,6 +14,7 @@
 
 <script>
 import uuid from 'uuid';
+import Vue from 'vue';
 import ProductList from './ProductList';
 import SaveProductForm from './SaveProductForm';
 
@@ -79,7 +80,9 @@ export default {
       this.productInForm = initialData().productInForm;
     },
     onEditClicked(product) {
-      this.productInForm = product;
+      // Since objects are passed by reference, we use a Vue utility to clone
+      // the product to be edited.
+      this.productInForm = Vue.util.extend({}, product);
     }
   }
 }


### PR DESCRIPTION
First off, really appreciate the workshop.   Its been very helpful in learning Vue.

I noticed an issue working on the "Cancel" button in the updating products exercise. The product object is passed directly to the form.  So any changes made in the form are immediately reflected in the product list as the object is being modified regardless of whether the form is "submitted" or not.

I made a slight change to clone the product object as its passed to the form for updating.