### PR TITLE
Import `bootstrap.scss` instead of `bootstrap-flex.scss`.

### DIFF
--- a/demo/src/styles/style.scss
+++ b/demo/src/styles/style.scss
@@ -1,6 +1,6 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";
 @import "cards";

--- a/exercise-files/async-api/src/styles/style.scss
+++ b/exercise-files/async-api/src/styles/style.scss
@@ -1,6 +1,6 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";
 @import "navbar";

--- a/exercise-files/create-products/src/styles/style.scss
+++ b/exercise-files/create-products/src/styles/style.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";

--- a/exercise-files/list-products/src/styles/style.scss
+++ b/exercise-files/list-products/src/styles/style.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";

--- a/exercise-files/remove-products/src/styles/style.scss
+++ b/exercise-files/remove-products/src/styles/style.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";

--- a/exercise-files/routing/src/styles/style.scss
+++ b/exercise-files/routing/src/styles/style.scss
@@ -1,6 +1,6 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";
 @import "navbar";

--- a/exercise-files/unidirectional-flow/src/styles/style.scss
+++ b/exercise-files/unidirectional-flow/src/styles/style.scss
@@ -1,6 +1,6 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";
 @import "navbar";

--- a/exercise-files/update-products/src/styles/style.scss
+++ b/exercise-files/update-products/src/styles/style.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
-@import "../../node_modules/bootstrap/scss/bootstrap-flex.scss";
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
 @import "base";


### PR DESCRIPTION
When running `npm run dev`, importing `bootstrap-flex.scss` raises an
error.

File bootstrap-flex.scss which is "flex-enable-wrapper" for bootstrap.scss has
been removed from bootstraps source code.  bootstrap.scss has flex enabled by
default now in branch v4-dev
(https://github.com/twbs/bootstrap/commit/eb2e1102be0f4641ee3e5c4e7853360d5a04e3d8).